### PR TITLE
Quotation handling

### DIFF
--- a/ppp_spell_checker/requesthandler.py
+++ b/ppp_spell_checker/requesthandler.py
@@ -31,7 +31,7 @@ class StringCorrector:
         A new instance of the object has to be created for each string.
     """
     quotationRegexp = '|'.join(r'{0}(?:\.|[^{0}{1}\\])*{1}'.format(quote[0], quote[1])
-        for quote in ['""', "''", '“”', '‘’', '«»']
+        for quote in ['""', '“”', '‘’', '«»']
     )
     def __init__(self, language):
         self.numberCorrections = 0

--- a/ppp_spell_checker/requesthandler.py
+++ b/ppp_spell_checker/requesthandler.py
@@ -30,8 +30,8 @@ class StringCorrector:
         A class to perform spell checking.
         A new instance of the object has to be created for each string.
     """
-    quotationRegexp = '|'.join(('{0}(?:\\\\.|[^{0}{1}\\\\])*{1}'.format(quote[0], quote[1]))
-        for quote in [('"', '"'), ("'", "'"), ('“', '”'), ('‘', '’'), ('«', '»')]
+    quotationRegexp = '|'.join(r'{0}(?:\.|[^{0}{1}\\])*{1}'.format(quote[0], quote[1])
+        for quote in ['""', "''", '“”', '‘’', '«»']
     )
     def __init__(self, language):
         self.numberCorrections = 0

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -51,7 +51,7 @@ class DependenciesTreeTests(TestCase):
 
     def testTrueSentencesQuotation(self):
         for quotes in itertools.permutations(
-                ['""', "''", '“”', '‘’', '«»'], 2):
+                ['""', '“”', '‘’', '«»'], 2):
             corrector = StringCorrector('en')
             original='Who %sis the%s president of the %sUnited States%s?' % (
                 quotes[0][0], quotes[0][1], quotes[1][0], quotes[1][1]
@@ -62,7 +62,7 @@ class DependenciesTreeTests(TestCase):
 
     def testFalseSentencesQuotation(self):
         for quotes in itertools.permutations(
-                ['""', "''", '“”', '‘’', '«»'], 2):
+                ['""', '“”', '‘’', '«»'], 2):
             corrector = StringCorrector('en')
             original='Who %sis the%s pesident of the %sUinted Statse%s?' % (
                 quotes[0][0], quotes[0][1], quotes[1][0], quotes[1][1]

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,15 +1,16 @@
+from unittest import TestCase
+import itertools
+
 from ppp_spell_checker import StringCorrector, Word
 import aspell
-
-from unittest import TestCase
 
 class DependenciesTreeTests(TestCase):
 
     def testBasicWordMethods(self):
         a=Word("foo",2)
         b=Word("foo",2)
-        self.assertEqual(a,b)
-        self.assertEqual(str(a),str(b))
+        self.assertEqual(a, b)
+        self.assertEqual(str(a), str(b))
 
     def testTokenization(self):
         corrector = StringCorrector('en')
@@ -17,7 +18,7 @@ class DependenciesTreeTests(TestCase):
         tokens = corrector.tokenize(s)
         self.assertEqual([w.string for w in tokens],['this','is','a','word','list','for','test','purpose'])
         for w in tokens:
-            self.assertEqual(w.string,s[w.beginOffset:w.beginOffset+len(w.string)])
+            self.assertEqual(w.string, s[w.beginOffset:w.beginOffset+len(w.string)])
 
     def testNumber(self):
         corrector = StringCorrector('en')
@@ -30,7 +31,7 @@ class DependenciesTreeTests(TestCase):
         corrector = StringCorrector('en')
         original='Who is the president of the United States?'
         corrected=corrector.correctString(original)
-        self.assertEqual(corrected,original)
+        self.assertEqual(corrected, original)
         self.assertEqual(corrector.numberCorrections,0)
 
     def testFalseSentences(self):
@@ -38,7 +39,7 @@ class DependenciesTreeTests(TestCase):
         original='Who is the pesident of the Uinted Statse?'
         corrected=corrector.correctString(original)
         expected='Who is the president of the United States?'
-        self.assertEqual(corrected,expected)
+        self.assertEqual(corrected, expected)
         self.assertEqual(corrector.numberCorrections,3)
 
     def testPunctuation(self):
@@ -46,26 +47,34 @@ class DependenciesTreeTests(TestCase):
         original=' * Who,. is! the : : pesident of the --- --- --- Uinted Statse? . ! '
         corrected=corrector.correctString(original)
         expected=' * Who,. is! the : : president of the --- --- --- United States? . ! '
-        self.assertEqual(corrected,expected)
+        self.assertEqual(corrected, expected)
 
     def testTrueSentencesQuotation(self):
-        corrector = StringCorrector('en')
-        original='Who "is the" president of the "United States"?'
-        corrected=corrector.correctString(original)
-        self.assertEqual(corrected,original)
-        self.assertEqual(corrector.numberCorrections,0)
+        for quotes in itertools.permutations(
+                [('"', '"'), ("'", "'"), ('“', '”'), ('‘', '’'), ('«', '»')], 2):
+            corrector = StringCorrector('en')
+            original='Who %sis the%s president of the %sUnited States%s?' % (
+                quotes[0][0], quotes[0][1], quotes[1][0], quotes[1][1]
+            )
+            corrected = corrector.correctString(original)
+            self.assertEqual(corrected, original)
+            self.assertEqual(corrector.numberCorrections,0)
 
     def testFalseSentencesQuotation(self):
-        corrector = StringCorrector('en')
-        original='Who "is the" pesident of the "Uinted Statse"?'
-        corrected=corrector.correctString(original)
-        expected='Who "is the" president of the "Uinted Statse"?'
-        self.assertEqual(corrected,expected)
-        self.assertEqual(corrector.numberCorrections,1)
+        for quotes in itertools.permutations(
+                [('"', '"'), ("'", "'"), ('“', '”'), ('‘', '’'), ('«', '»')], 2):
+            corrector = StringCorrector('en')
+            original='Who %sis the%s pesident of the %sUinted Statse%s?' % (
+                quotes[0][0], quotes[0][1], quotes[1][0], quotes[1][1]
+            )
+            corrected = corrector.correctString(original)
+            expected = original.replace('pesident', 'president')
+            self.assertEqual(corrected, expected)
+            self.assertEqual(corrector.numberCorrections, 1)
 
     def testPunctuationQuotation(self):
         corrector = StringCorrector('en')
-        original=' * Who,. "is! the ": : pesident “of” the ‘---’ --- --"- Uinted Statse? ." ! '
+        original=' * Who,. “is! the ”: : pesident “of” the ‘---’ --- --"- Uinted Statse? ." ! '
         corrected=corrector.correctString(original)
-        expected=' * Who,. "is! the ": : president “of” the ‘---’ --- --"- Uinted Statse? ." ! '
-        self.assertEqual(corrected,expected)
+        expected=' * Who,. “is! the ”: : president “of” the ‘---’ --- --"- Uinted Statse? ." ! '
+        self.assertEqual(corrected, expected)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -78,3 +78,9 @@ class DependenciesTreeTests(TestCase):
         corrected=corrector.correctString(original)
         expected=' * Who,. “is! the ”: : president “of” the ‘---’ --- --"- Uinted Statse? ." ! '
         self.assertEqual(corrected, expected)
+
+    def testApostrophe(self):
+        corrector = StringCorrector('en')
+        original='I’m a string with a ‘quotation’.'
+        corrected=corrector.correctString(original)
+        self.assertEqual(corrected, original)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -51,7 +51,7 @@ class DependenciesTreeTests(TestCase):
 
     def testTrueSentencesQuotation(self):
         for quotes in itertools.permutations(
-                [('"', '"'), ("'", "'"), ('“', '”'), ('‘', '’'), ('«', '»')], 2):
+                ['""', "''", '“”', '‘’', '«»'], 2):
             corrector = StringCorrector('en')
             original='Who %sis the%s president of the %sUnited States%s?' % (
                 quotes[0][0], quotes[0][1], quotes[1][0], quotes[1][1]
@@ -62,7 +62,7 @@ class DependenciesTreeTests(TestCase):
 
     def testFalseSentencesQuotation(self):
         for quotes in itertools.permutations(
-                [('"', '"'), ("'", "'"), ('“', '”'), ('‘', '’'), ('«', '»')], 2):
+                ['""', "''", '“”', '‘’', '«»'], 2):
             corrector = StringCorrector('en')
             original='Who %sis the%s pesident of the %sUinted Statse%s?' % (
                 quotes[0][0], quotes[0][1], quotes[1][0], quotes[1][1]


### PR DESCRIPTION
Use a regexp to handle quotations.

Before, any ugly quotation was recognized (for instance `“foo“`, with an openning quotation mark to close the quotation). Now we only recognize quotations with a correct syntax.

This allows quotations marks within a quotation (like in python).
